### PR TITLE
Added NPC complaint system

### DIFF
--- a/src/main/java/rbasamoyai/industrialwarfare/IndustrialWarfare.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/IndustrialWarfare.java
@@ -34,6 +34,7 @@ import rbasamoyai.industrialwarfare.core.init.ContainerInit;
 import rbasamoyai.industrialwarfare.core.init.EntityTypeInit;
 import rbasamoyai.industrialwarfare.core.init.ItemInit;
 import rbasamoyai.industrialwarfare.core.init.MemoryModuleTypeInit;
+import rbasamoyai.industrialwarfare.core.init.NPCComplaintInit;
 import rbasamoyai.industrialwarfare.core.init.RecipeInit;
 import rbasamoyai.industrialwarfare.core.init.TaskScrollCommandInit;
 import rbasamoyai.industrialwarfare.core.init.TileEntityTypeInit;
@@ -63,6 +64,7 @@ public class IndustrialWarfare {
 		modEventBus.register(EntityTypeInit.class);
 		modEventBus.register(MemoryModuleTypeInit.class);
 		
+		modEventBus.register(NPCComplaintInit.class);
 		modEventBus.register(TaskScrollCommandInit.class);
 		
 		ModLoadingContext.get().registerConfig(Type.SERVER, IWConfig.SPEC, "industrialwarfare-server.toml");

--- a/src/main/java/rbasamoyai/industrialwarfare/client/entities/renderers/NPCRenderer.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/client/entities/renderers/NPCRenderer.java
@@ -1,7 +1,10 @@
 package rbasamoyai.industrialwarfare.client.entities.renderers;
 
+import java.util.Optional;
+
 import com.mojang.blaze3d.matrix.MatrixStack;
 
+import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.client.renderer.entity.BipedRenderer;
 import net.minecraft.client.renderer.entity.EntityRendererManager;
 import net.minecraft.client.renderer.entity.layers.BipedArmorLayer;
@@ -9,6 +12,8 @@ import net.minecraft.client.renderer.entity.model.BipedModel;
 import net.minecraft.util.ResourceLocation;
 import rbasamoyai.industrialwarfare.client.entities.models.NPCModel;
 import rbasamoyai.industrialwarfare.common.entities.NPCEntity;
+import rbasamoyai.industrialwarfare.common.entityai.NPCComplaint;
+import rbasamoyai.industrialwarfare.core.init.MemoryModuleTypeInit;
 
 /*
  * Base NPC renderer class
@@ -28,6 +33,18 @@ public class NPCRenderer<T extends NPCEntity> extends BipedRenderer<T, NPCModel<
 	protected void scale(T entity, MatrixStack stack, float scale) {
 		float f = 0.9375F;
 		stack.scale(f, f, f);
+	}
+	
+	@Override
+	public void render(T npc, float p_225623_2_, float partialTicks, MatrixStack stack, IRenderTypeBuffer buf, int packedLight) {
+		super.render(npc, p_225623_2_, partialTicks, stack, buf, packedLight);
+		Optional<NPCComplaint> complaint = npc.getBrain().getMemory(MemoryModuleTypeInit.COMPLAINT);
+		if (complaint.isPresent()) {
+			stack.pushPose();
+			stack.translate(0.0d, 0.25d, 0.0d);
+			this.renderNameTag(npc, complaint.get().getMessage(), stack, buf, packedLight);
+			stack.popPose();
+		}
 	}
 
 	@Override

--- a/src/main/java/rbasamoyai/industrialwarfare/common/entities/NPCEntity.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/common/entities/NPCEntity.java
@@ -39,6 +39,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fml.network.NetworkHooks;
+import net.minecraftforge.fml.network.PacketDistributor;
 import net.minecraftforge.items.ItemStackHandler;
 import rbasamoyai.industrialwarfare.IndustrialWarfare;
 import rbasamoyai.industrialwarfare.common.capabilities.entities.npc.INPCDataHandler;
@@ -50,6 +51,9 @@ import rbasamoyai.industrialwarfare.common.entityai.NPCTasks;
 import rbasamoyai.industrialwarfare.common.items.ScheduleItem;
 import rbasamoyai.industrialwarfare.core.init.ItemInit;
 import rbasamoyai.industrialwarfare.core.init.MemoryModuleTypeInit;
+import rbasamoyai.industrialwarfare.core.init.NPCComplaintInit;
+import rbasamoyai.industrialwarfare.core.network.IWNetwork;
+import rbasamoyai.industrialwarfare.core.network.messages.CNPCBrainDataSyncMessage;
 import rbasamoyai.industrialwarfare.utils.TimeUtils;
 
 /*
@@ -68,7 +72,7 @@ public class NPCEntity extends CreatureEntity {
 			MemoryModuleType.VISIBLE_LIVING_ENTITIES,
 			MemoryModuleType.PATH,
 			MemoryModuleType.WALK_TARGET,
-			MemoryModuleTypeInit.CANT_INTERFACE,
+			MemoryModuleTypeInit.COMPLAINT,
 			MemoryModuleTypeInit.CURRENT_INSTRUCTION_INDEX,
 			MemoryModuleTypeInit.EXECUTING_INSTRUCTION,
 			MemoryModuleTypeInit.JUMP_TO,
@@ -210,6 +214,10 @@ public class NPCEntity extends CreatureEntity {
 		} else if (!shouldWork && !isWorking) {
 			brain.setActiveActivityIfPossible(Activity.IDLE);
 		}
+		
+		CNPCBrainDataSyncMessage msg = new CNPCBrainDataSyncMessage(this.getId(), brain.getMemory(MemoryModuleTypeInit.COMPLAINT).orElse(NPCComplaintInit.CLEAR), this.blockPosition()); 
+		IWNetwork.CHANNEL.send(PacketDistributor.TRACKING_ENTITY.with(() -> this), msg);
+		
 		super.customServerAiStep();
 	}
 	

--- a/src/main/java/rbasamoyai/industrialwarfare/common/entityai/NPCComplaint.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/common/entityai/NPCComplaint.java
@@ -1,0 +1,36 @@
+package rbasamoyai.industrialwarfare.common.entityai;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
+import net.minecraftforge.registries.ForgeRegistryEntry;
+import rbasamoyai.industrialwarfare.IndustrialWarfare;
+import rbasamoyai.industrialwarfare.core.IWModRegistries;
+
+public class NPCComplaint extends ForgeRegistryEntry<NPCComplaint> {
+
+	public static final Codec<NPCComplaint> CODEC = Codec.STRING.comapFlatMap(NPCComplaint::read, NPCComplaint::toString).stable();
+	
+	private static final String COMPLAINT_ROOT = "complaint.";
+	
+	public NPCComplaint(String complaintId) {
+		this.setRegistryName(IndustrialWarfare.MOD_ID, complaintId);
+	}
+	
+	public ITextComponent getMessage() {
+		return new TranslationTextComponent(COMPLAINT_ROOT + this.getRegistryName().getNamespace() + "." + this.getRegistryName().getPath());
+	}
+	
+	private static DataResult<NPCComplaint> read(String id) {
+		return DataResult.success(IWModRegistries.NPC_COMPLAINTS.getValue(new ResourceLocation(id)));
+	}
+	
+	@Override
+	public String toString() {
+		return this.getRegistryName().toString();
+	}
+	
+}

--- a/src/main/java/rbasamoyai/industrialwarfare/common/entityai/tasks/RunCommandFromTaskScrollTask.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/common/entityai/tasks/RunCommandFromTaskScrollTask.java
@@ -27,7 +27,7 @@ public class RunCommandFromTaskScrollTask extends Task<NPCEntity> {
 				.put(MemoryModuleType.HEARD_BELL_TIME, MemoryModuleStatus.REGISTERED)
 				.put(MemoryModuleType.JOB_SITE, MemoryModuleStatus.VALUE_PRESENT)
 				.put(MemoryModuleType.WALK_TARGET, MemoryModuleStatus.REGISTERED)
-				.put(MemoryModuleTypeInit.CANT_INTERFACE, MemoryModuleStatus.REGISTERED)
+				.put(MemoryModuleTypeInit.COMPLAINT, MemoryModuleStatus.REGISTERED)
 				.put(MemoryModuleTypeInit.CURRENT_INSTRUCTION_INDEX, MemoryModuleStatus.REGISTERED)
 				.put(MemoryModuleTypeInit.EXECUTING_INSTRUCTION, MemoryModuleStatus.REGISTERED)
 				.put(MemoryModuleTypeInit.JUMP_TO, MemoryModuleStatus.REGISTERED)
@@ -42,7 +42,7 @@ public class RunCommandFromTaskScrollTask extends Task<NPCEntity> {
 		Brain<?> brain = npc.getBrain();
 		if (!brain.getMemory(MemoryModuleTypeInit.WORKING).orElse(false)
 				|| brain.getMemory(MemoryModuleTypeInit.EXECUTING_INSTRUCTION).orElse(false)
-				|| brain.hasMemoryValue(MemoryModuleTypeInit.CANT_INTERFACE)) {
+				|| brain.hasMemoryValue(MemoryModuleTypeInit.COMPLAINT)) {
 			return false;
 		}
 		
@@ -104,7 +104,7 @@ public class RunCommandFromTaskScrollTask extends Task<NPCEntity> {
 		return brain.getMemory(MemoryModuleTypeInit.WORKING).orElse(false)
 				&& brain.getMemory(MemoryModuleTypeInit.EXECUTING_INSTRUCTION).orElse(false)
 				&& !brain.hasMemoryValue(MemoryModuleTypeInit.STOP_EXECUTION)
-				&& !brain.hasMemoryValue(MemoryModuleTypeInit.CANT_INTERFACE);
+				&& !brain.hasMemoryValue(MemoryModuleTypeInit.COMPLAINT);
 	}
 	
 	@Override

--- a/src/main/java/rbasamoyai/industrialwarfare/common/entityai/taskscrollcmds/DepositAtCommand.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/common/entityai/taskscrollcmds/DepositAtCommand.java
@@ -24,6 +24,7 @@ import rbasamoyai.industrialwarfare.common.entities.NPCEntity;
 import rbasamoyai.industrialwarfare.common.entityai.taskscrollcmds.commandtree.CommandTrees;
 import rbasamoyai.industrialwarfare.common.items.taskscroll.TaskScrollOrder;
 import rbasamoyai.industrialwarfare.core.init.MemoryModuleTypeInit;
+import rbasamoyai.industrialwarfare.core.init.NPCComplaintInit;
 import rbasamoyai.industrialwarfare.utils.ArgUtils;
 
 public class DepositAtCommand extends TaskScrollCommand {
@@ -40,16 +41,16 @@ public class DepositAtCommand extends TaskScrollCommand {
 	
 	@Override
 	public boolean checkExtraStartConditions(ServerWorld world, NPCEntity npc, TaskScrollOrder order) {
+		Brain<?> brain = npc.getBrain();
 		Optional<BlockPos> pos = order.getWrappedArg(POS_ARG_INDEX).getPos();
 		if (!pos.isPresent()) {
-			// TODO: complain that order can't be read
+			brain.setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.INVALID_ORDER);
 			return false;
 		}
 		
 		boolean result = pos.get().closerThan(npc.position(), TaskScrollCommand.MAX_DISTANCE_FROM_POI);
 		if (!result) {
-			// TODO: do some complaining that target is too far
-			
+			brain.setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.TOO_FAR);
 		}
 		return result;
 	}
@@ -68,8 +69,7 @@ public class DepositAtCommand extends TaskScrollCommand {
 			brain.setMemory(MemoryModuleType.WALK_TARGET, new WalkTarget(pos, TaskScrollCommand.SPEED_MODIFIER, TaskScrollCommand.CLOSE_ENOUGH_DIST));
 		});
 		if (!accessPos.isPresent()) {
-			// TODO: Complain that area cannot be accessed
-			brain.setMemory(MemoryModuleTypeInit.CANT_INTERFACE, true);
+			brain.setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.CANT_ACCESS);
 		}
 	}
 
@@ -107,9 +107,12 @@ public class DepositAtCommand extends TaskScrollCommand {
 					brain.setMemory(MemoryModuleTypeInit.STOP_EXECUTION, true);
 				});
 				if (!blockInvOptional.isPresent()) {
-					// TODO: Complain that there's nothing to access here
-					brain.setMemory(MemoryModuleTypeInit.CANT_INTERFACE, true);
+					brain.setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.CANT_OPEN);
 				}
+			} else if (te == null) {
+				brain.setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.NOTHING_HERE);
+			} else if (!box.contains(npc.position())) {
+				brain.setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.CANT_ACCESS);
 			}
 		}
 	}
@@ -117,7 +120,7 @@ public class DepositAtCommand extends TaskScrollCommand {
 	@Override
 	public void stop(ServerWorld world, NPCEntity npc, long gameTime, TaskScrollOrder order) {
 		Brain<?> brain = npc.getBrain();
-		if (!brain.hasMemoryValue(MemoryModuleTypeInit.CANT_INTERFACE)) {
+		if (!brain.hasMemoryValue(MemoryModuleTypeInit.COMPLAINT)) {
 			brain.setMemory(MemoryModuleTypeInit.CURRENT_INSTRUCTION_INDEX, brain.getMemory(MemoryModuleTypeInit.CURRENT_INSTRUCTION_INDEX).orElse(0) + 1);
 		}
 	}

--- a/src/main/java/rbasamoyai/industrialwarfare/common/entityai/taskscrollcmds/JumpToCommand.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/common/entityai/taskscrollcmds/JumpToCommand.java
@@ -15,6 +15,7 @@ import rbasamoyai.industrialwarfare.common.entityai.taskscrollcmds.commandtree.C
 import rbasamoyai.industrialwarfare.common.items.taskscroll.TaskScrollItem;
 import rbasamoyai.industrialwarfare.common.items.taskscroll.TaskScrollOrder;
 import rbasamoyai.industrialwarfare.core.init.MemoryModuleTypeInit;
+import rbasamoyai.industrialwarfare.core.init.NPCComplaintInit;
 import rbasamoyai.industrialwarfare.utils.ArgUtils;
 
 public class JumpToCommand extends TaskScrollCommand {
@@ -34,7 +35,7 @@ public class JumpToCommand extends TaskScrollCommand {
 		LazyOptional<ITaskScrollDataHandler> optional = TaskScrollItem.getDataHandler(scroll);
 		
 		if (!optional.map(h -> 0 <= jumpPos || jumpPos < h.getList().size()).orElse(false)) {
-			// TODO: Complain that position is not valid
+			npc.getBrain().setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.INVALID_ORDER);
 			return false;
 		} else {
 			return true;

--- a/src/main/java/rbasamoyai/industrialwarfare/common/entityai/taskscrollcmds/MoveToCommand.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/common/entityai/taskscrollcmds/MoveToCommand.java
@@ -13,6 +13,7 @@ import rbasamoyai.industrialwarfare.common.entities.NPCEntity;
 import rbasamoyai.industrialwarfare.common.entityai.taskscrollcmds.commandtree.CommandTrees;
 import rbasamoyai.industrialwarfare.common.items.taskscroll.TaskScrollOrder;
 import rbasamoyai.industrialwarfare.core.init.MemoryModuleTypeInit;
+import rbasamoyai.industrialwarfare.core.init.NPCComplaintInit;
 
 public class MoveToCommand extends TaskScrollCommand {
 	
@@ -27,7 +28,7 @@ public class MoveToCommand extends TaskScrollCommand {
 	public boolean checkExtraStartConditions(ServerWorld world, NPCEntity npc, TaskScrollOrder order) {
 		Optional<BlockPos> pos = order.getWrappedArg(POS_ARG_INDEX).getPos();
 		if (!pos.isPresent()) {
-			// TODO: complain that order can't be read
+			npc.getBrain().setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.INVALID_ORDER);
 			return false;
 		}
 		

--- a/src/main/java/rbasamoyai/industrialwarfare/common/entityai/taskscrollcmds/SwitchOrderCommand.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/common/entityai/taskscrollcmds/SwitchOrderCommand.java
@@ -28,6 +28,7 @@ import rbasamoyai.industrialwarfare.common.items.LabelItem;
 import rbasamoyai.industrialwarfare.common.items.taskscroll.TaskScrollItem;
 import rbasamoyai.industrialwarfare.common.items.taskscroll.TaskScrollOrder;
 import rbasamoyai.industrialwarfare.core.init.MemoryModuleTypeInit;
+import rbasamoyai.industrialwarfare.core.init.NPCComplaintInit;
 
 public class SwitchOrderCommand extends TaskScrollCommand {
 
@@ -52,7 +53,7 @@ public class SwitchOrderCommand extends TaskScrollCommand {
 		
 		if (mode == PosModes.GET_FROM_POS) {
 			if (!optional.isPresent()) {
-				// TODO: complain that order can't be read
+				brain.setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.INVALID_ORDER);
 				return false;
 			} else {
 				pos = optional.get();
@@ -63,8 +64,7 @@ public class SwitchOrderCommand extends TaskScrollCommand {
 		
 		boolean result = pos.closerThan(npc.position(), TaskScrollCommand.MAX_DISTANCE_FROM_POI);
 		if (!result) {
-			// TODO: do some complaining that target is too far
-			
+			brain.setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.TOO_FAR);
 		}
 		return result;
 	}
@@ -85,8 +85,7 @@ public class SwitchOrderCommand extends TaskScrollCommand {
 			brain.setMemory(MemoryModuleType.WALK_TARGET, new WalkTarget(pos, TaskScrollCommand.SPEED_MODIFIER, TaskScrollCommand.CLOSE_ENOUGH_DIST));
 		});
 		if (!accessPos.isPresent()) {
-			// TODO: Complain that area cannot be accessed
-			brain.setMemory(MemoryModuleTypeInit.CANT_INTERFACE, true);
+			brain.setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.CANT_ACCESS);
 		}
 	}
 
@@ -126,14 +125,16 @@ public class SwitchOrderCommand extends TaskScrollCommand {
 					}
 					
 					if (!switched) {
-						// TODO: complain that can't find scroll
-						brain.setMemory(MemoryModuleTypeInit.CANT_INTERFACE, true);
+						brain.setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.CANT_GET_ITEM);
 					}
 				});
 				if (!blockInvOptional.isPresent()) {
-					// TODO: Complain that there's nothing to access here
-					brain.setMemory(MemoryModuleTypeInit.CANT_INTERFACE, true);
+					brain.setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.CANT_OPEN);
 				}
+			} else if (te == null) {
+				brain.setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.NOTHING_HERE);
+			} else if (!box.contains(npc.position())) {
+				brain.setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.CANT_ACCESS);
 			}
 		}
 	}
@@ -177,14 +178,16 @@ public class SwitchOrderCommand extends TaskScrollCommand {
 				}
 				
 				if (!switched) {
-					// TODO: complain that can't find scroll
-					brain.setMemory(MemoryModuleTypeInit.CANT_INTERFACE, true);
+					brain.setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.CANT_GET_ITEM);
 				}
 			});
 			if (!blockInvOptional.isPresent()) {
-				// TODO: Complain that there's nothing to access here
-				brain.setMemory(MemoryModuleTypeInit.CANT_INTERFACE, true);
+				brain.setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.CANT_OPEN);
 			}
+		} else if (te == null) {
+			brain.setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.NOTHING_HERE);
+		} else if (!box.contains(npc.position())) {
+			brain.setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.CANT_ACCESS);
 		}
 	}
 	

--- a/src/main/java/rbasamoyai/industrialwarfare/common/entityai/taskscrollcmds/WaitForCommand.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/common/entityai/taskscrollcmds/WaitForCommand.java
@@ -9,6 +9,7 @@ import rbasamoyai.industrialwarfare.common.entities.NPCEntity;
 import rbasamoyai.industrialwarfare.common.entityai.taskscrollcmds.commandtree.CommandTrees;
 import rbasamoyai.industrialwarfare.common.items.taskscroll.TaskScrollOrder;
 import rbasamoyai.industrialwarfare.core.init.MemoryModuleTypeInit;
+import rbasamoyai.industrialwarfare.core.init.NPCComplaintInit;
 import rbasamoyai.industrialwarfare.utils.TimeUtils;
 
 public class WaitForCommand extends TaskScrollCommand {
@@ -27,7 +28,8 @@ public class WaitForCommand extends TaskScrollCommand {
 		boolean doingDaylightCycle = world.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT);
 		
 		if (waitMode == WaitModes.DAY_TIME && !doingDaylightCycle) {
-			// TODO: complain that the day isn't running - somehow they sense that doDaylightCycle is false, don't ask how
+			// somehow the NPCs sense that doDaylightCycle is false, don't ask how
+			npc.getBrain().setMemory(MemoryModuleTypeInit.COMPLAINT, NPCComplaintInit.TIME_STOPPED);
 		}
 		
 		return waitMode == WaitModes.DAY_TIME && doingDaylightCycle || waitMode == WaitModes.RELATIVE_TIME || waitMode == WaitModes.BELL;

--- a/src/main/java/rbasamoyai/industrialwarfare/core/IWModRegistries.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/core/IWModRegistries.java
@@ -10,6 +10,7 @@ import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.RegistryBuilder;
 import rbasamoyai.industrialwarfare.IndustrialWarfare;
+import rbasamoyai.industrialwarfare.common.entityai.NPCComplaint;
 import rbasamoyai.industrialwarfare.common.entityai.taskscrollcmds.TaskScrollCommand;
 
 /**
@@ -21,24 +22,33 @@ import rbasamoyai.industrialwarfare.common.entityai.taskscrollcmds.TaskScrollCom
 @EventBusSubscriber(modid = IndustrialWarfare.MOD_ID, bus = Bus.MOD)
 public class IWModRegistries {
 	
+	public static IForgeRegistry<NPCComplaint> NPC_COMPLAINTS = null;
 	public static IForgeRegistry<TaskScrollCommand> TASK_SCROLL_COMMANDS = null;
 	
 	@SubscribeEvent
 	public static void buildModRegistries(RegistryEvent.NewRegistry event) {
 		IndustrialWarfare.LOGGER.info("Starting registry building for IndustrialWarfare by rbasamoyai");
 		
-		RegistryBuilder<TaskScrollCommand> taskScrollCommandRegistryBuilder = new RegistryBuilder<>();
-		TASK_SCROLL_COMMANDS = taskScrollCommandRegistryBuilder
+		NPC_COMPLAINTS = new RegistryBuilder<NPCComplaint>()
+				.setName(KEY_NPC_COMPLAINTS.location())
+				.setMaxID(MAX_ID)
+				.setType(NPCComplaint.class)
+				.setDefaultKey(new ResourceLocation(IndustrialWarfare.MOD_ID, "cant_open"))
+				.allowModification()
+				.create();
+		
+		TASK_SCROLL_COMMANDS = new RegistryBuilder<TaskScrollCommand>() 
 				.setName(KEY_TASK_COMMANDS.location())
 				.setMaxID(MAX_ID)
 				.setType(TaskScrollCommand.class)
-				.setDefaultKey(new ResourceLocation("move_to"))
+				.setDefaultKey(new ResourceLocation(IndustrialWarfare.MOD_ID, "move_to"))
 				.allowModification()
 				.create();
 		
 		IndustrialWarfare.LOGGER.info("Finished registry building for Industrial Warfare by rbasamoyai");
 	}
 	
+	private static final RegistryKey<Registry<NPCComplaint>> KEY_NPC_COMPLAINTS = key("npc_complaints");
 	private static final RegistryKey<Registry<TaskScrollCommand>> KEY_TASK_COMMANDS = key("task_commands");
 	
 	private static final int MAX_ID = Integer.MAX_VALUE - 1;

--- a/src/main/java/rbasamoyai/industrialwarfare/core/init/MemoryModuleTypeInit.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/core/init/MemoryModuleTypeInit.java
@@ -11,12 +11,13 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 import net.minecraftforge.registries.ObjectHolder;
 import rbasamoyai.industrialwarfare.IndustrialWarfare;
+import rbasamoyai.industrialwarfare.common.entityai.NPCComplaint;
 
 @Mod.EventBusSubscriber(modid = IndustrialWarfare.MOD_ID, bus = Bus.MOD)
 @ObjectHolder(IndustrialWarfare.MOD_ID)
 public class MemoryModuleTypeInit {
 
-	public static final MemoryModuleType<Boolean> CANT_INTERFACE = null;
+	public static final MemoryModuleType<NPCComplaint> COMPLAINT = null;
 	public static final MemoryModuleType<Integer> CURRENT_INSTRUCTION_INDEX = null;
 	public static final MemoryModuleType<Boolean> EXECUTING_INSTRUCTION = null;
 	public static final MemoryModuleType<Integer> JUMP_TO = null;
@@ -27,7 +28,7 @@ public class MemoryModuleTypeInit {
 	@SubscribeEvent
 	public static void registerMemoryModuleTypes(RegistryEvent.Register<MemoryModuleType<?>> event) {
 		event.getRegistry().registerAll(new MemoryModuleType<?>[] {
-			new MemoryModuleType<>(Optional.of(Codec.BOOL)).setRegistryName(IndustrialWarfare.MOD_ID, "cant_interface"),
+			new MemoryModuleType<>(Optional.of(NPCComplaint.CODEC)).setRegistryName(IndustrialWarfare.MOD_ID, "complaint"),
 			new MemoryModuleType<>(Optional.of(Codec.INT)).setRegistryName(IndustrialWarfare.MOD_ID, "current_instruction_index"),
 			new MemoryModuleType<>(Optional.of(Codec.BOOL)).setRegistryName(IndustrialWarfare.MOD_ID, "executing_instruction"),
 			new MemoryModuleType<>(Optional.empty()).setRegistryName(IndustrialWarfare.MOD_ID, "jump_to"),

--- a/src/main/java/rbasamoyai/industrialwarfare/core/init/NPCComplaintInit.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/core/init/NPCComplaintInit.java
@@ -1,0 +1,40 @@
+package rbasamoyai.industrialwarfare.core.init;
+
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
+import net.minecraftforge.registries.ObjectHolder;
+import rbasamoyai.industrialwarfare.IndustrialWarfare;
+import rbasamoyai.industrialwarfare.common.entityai.NPCComplaint;
+
+@Mod.EventBusSubscriber(modid = IndustrialWarfare.MOD_ID, bus = Bus.MOD)
+@ObjectHolder(IndustrialWarfare.MOD_ID)
+public class NPCComplaintInit {
+	
+	public static final NPCComplaint CANT_ACCESS = null;
+	public static final NPCComplaint CANT_DEPOSIT_ITEM = null;
+	public static final NPCComplaint CANT_GET_ITEM = null;
+	public static final NPCComplaint CANT_OPEN = null;
+	public static final NPCComplaint CLEAR = null;
+	public static final NPCComplaint INVALID_ORDER = null;
+	public static final NPCComplaint NOTHING_HERE = null;
+	public static final NPCComplaint TIME_STOPPED = null;
+	public static final NPCComplaint TOO_FAR = null;
+	
+	@SubscribeEvent
+	public static void registerNPCComplaints(RegistryEvent.Register<NPCComplaint> event) {
+		event.getRegistry().registerAll(new NPCComplaint[] {
+				new NPCComplaint("cant_access"),
+				new NPCComplaint("cant_deposit_item"),
+				new NPCComplaint("cant_get_item"),
+				new NPCComplaint("cant_open"),
+				new NPCComplaint("clear"),
+				new NPCComplaint("invalid_order"),
+				new NPCComplaint("nothing_here"),
+				new NPCComplaint("time_stopped"),
+				new NPCComplaint("too_far")
+		});
+	}
+	
+}

--- a/src/main/java/rbasamoyai/industrialwarfare/core/network/IWNetwork.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/core/network/IWNetwork.java
@@ -4,6 +4,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.network.NetworkRegistry;
 import net.minecraftforge.fml.network.simple.SimpleChannel;
 import rbasamoyai.industrialwarfare.IndustrialWarfare;
+import rbasamoyai.industrialwarfare.core.network.messages.CNPCBrainDataSyncMessage;
 import rbasamoyai.industrialwarfare.core.network.messages.SEditLabelSyncMessage;
 import rbasamoyai.industrialwarfare.core.network.messages.SEditScheduleSyncMessage;
 import rbasamoyai.industrialwarfare.core.network.messages.SNPCContainerActivateMessage;
@@ -12,7 +13,7 @@ import rbasamoyai.industrialwarfare.core.network.messages.SWorkstationPlayerActi
 
 public class IWNetwork {
 
-	public static final String NETWORK_VERSION = "0.2.1";
+	public static final String NETWORK_VERSION = "0.3.1";
 
 	public static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(
 			new ResourceLocation(IndustrialWarfare.MOD_ID, "network"), () -> NETWORK_VERSION, NETWORK_VERSION::equals,
@@ -26,6 +27,7 @@ public class IWNetwork {
 		CHANNEL.registerMessage(id++, SEditLabelSyncMessage.class, SEditLabelSyncMessage::encode, SEditLabelSyncMessage::decode, SEditLabelSyncMessage::handle);
 		CHANNEL.registerMessage(id++, SEditScheduleSyncMessage.class, SEditScheduleSyncMessage::encode, SEditScheduleSyncMessage::decode, SEditScheduleSyncMessage::handle);
 		CHANNEL.registerMessage(id++, SNPCContainerActivateMessage.class, SNPCContainerActivateMessage::encode, SNPCContainerActivateMessage::decode, SNPCContainerActivateMessage::handle);
+		CHANNEL.registerMessage(id++, CNPCBrainDataSyncMessage.class, CNPCBrainDataSyncMessage::encode, CNPCBrainDataSyncMessage::decode, CNPCBrainDataSyncMessage::handle);
 	}
 
 }

--- a/src/main/java/rbasamoyai/industrialwarfare/core/network/handlers/CNPCBrainDataSyncHandler.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/core/network/handlers/CNPCBrainDataSyncHandler.java
@@ -1,0 +1,29 @@
+package rbasamoyai.industrialwarfare.core.network.handlers;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.ai.brain.Brain;
+import net.minecraft.world.World;
+import rbasamoyai.industrialwarfare.common.entities.NPCEntity;
+import rbasamoyai.industrialwarfare.core.init.MemoryModuleTypeInit;
+import rbasamoyai.industrialwarfare.core.init.NPCComplaintInit;
+import rbasamoyai.industrialwarfare.core.network.messages.CNPCBrainDataSyncMessage;
+
+public class CNPCBrainDataSyncHandler {
+
+	public static void handle(CNPCBrainDataSyncMessage msg) {
+		Minecraft mc = Minecraft.getInstance();
+		World world = mc.player.level;
+		Entity e = world.getEntity(msg.id);
+		if (e != null && e instanceof NPCEntity) {
+			NPCEntity npc = (NPCEntity) e;
+			Brain<?> brain = npc.getBrain();
+			if (msg.complaint == NPCComplaintInit.CLEAR) {
+				brain.eraseMemory(MemoryModuleTypeInit.COMPLAINT);
+			} else {
+				brain.setMemory(MemoryModuleTypeInit.COMPLAINT, msg.complaint);
+			}
+		}
+	}
+	
+}

--- a/src/main/java/rbasamoyai/industrialwarfare/core/network/messages/CNPCBrainDataSyncMessage.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/core/network/messages/CNPCBrainDataSyncMessage.java
@@ -1,0 +1,51 @@
+package rbasamoyai.industrialwarfare.core.network.messages;
+
+import java.util.function.Supplier;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.network.NetworkEvent;
+import rbasamoyai.industrialwarfare.common.entityai.NPCComplaint;
+import rbasamoyai.industrialwarfare.core.IWModRegistries;
+import rbasamoyai.industrialwarfare.core.network.handlers.CNPCBrainDataSyncHandler;
+
+public class CNPCBrainDataSyncMessage {
+
+	public int id;
+	public NPCComplaint complaint;
+	public BlockPos pos;
+	
+	public CNPCBrainDataSyncMessage() {
+	}
+	
+	public CNPCBrainDataSyncMessage(int id, NPCComplaint complaint, BlockPos pos) {
+		this.id = id;
+		this.complaint = complaint;
+		this.pos = pos;
+	}
+	
+	public static void encode(CNPCBrainDataSyncMessage msg, PacketBuffer buf) {
+		buf.writeVarInt(msg.id);
+		buf
+				.writeResourceLocation(msg.complaint.getRegistryName())
+				.writeBlockPos(msg.pos);
+	}
+	
+	public static CNPCBrainDataSyncMessage decode(PacketBuffer buf) {
+		int id = buf.readVarInt();
+		NPCComplaint complaint = IWModRegistries.NPC_COMPLAINTS.getValue(buf.readResourceLocation());
+		BlockPos pos = buf.readBlockPos();
+		return new CNPCBrainDataSyncMessage(id, complaint, pos);
+	}
+	
+	public static void handle(CNPCBrainDataSyncMessage msg, Supplier<NetworkEvent.Context> contextSupplier) {
+		NetworkEvent.Context context = contextSupplier.get();
+		context.enqueueWork(() -> {
+			DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> CNPCBrainDataSyncHandler.handle(msg));
+		});
+		context.setPacketHandled(true);
+	}
+	
+}

--- a/src/main/resources/assets/industrialwarfare/lang/en_us.json
+++ b/src/main/resources/assets/industrialwarfare/lang/en_us.json
@@ -258,5 +258,16 @@
 	"command.industrialwarfare.jump_to":	"Jump to",
 	"command.industrialwarfare.switch_order":	"Switch order",
 	
-	"command.industrialwarfare.args.filter":	"Filter"
+	"command.industrialwarfare.args.filter":	"Filter",
+	
+	"complaint.industrialwarfare.cant_access":		"I can't access this place.",
+	"complaint.industrialwarfare.cant_deposit_item":	"I can't deposit something here.",
+	"complaint.industrialwarfare.cant_get_item":	"I can't get something here.",
+	"complaint.industrialwarfare.cant_open":		"I can't open the storage here.",
+	"complaint.industrialwarfare.clear":			"Fine day, isn't it?",
+	"complaint.industrialwarfare.invalid_order":	"I can't read this order.",
+	"complaint.industrialwarfare.nothing_here":		"There is nothing to access here.",
+	"complaint.industrialwarfare.time_stopped":		"For some reason it just feels like time isn't running.",
+	"complaint.industrialwarfare.too_far":			"I can't reach that place, it's too far away."
+	
 }


### PR DESCRIPTION
Va t'en, saint-simonaque de fucking enfant!

---
- NPCs will now complain if they can't do something, e.g. access an area, open a storage block, etc.
    - Added `NPCComplaint`
        - Complaints are only through messages, which are `TranslationTextComponents` supplied via `NPCComplaint#getMessage`
        - Added `NPCComplaintInit` to initialize `NPCComplaint`s
        - Added `IWModRegistries#NPC_COMPLAINTS`
    - Replaced `MemoryModuleTypeInit#CANT_INTERFACE` with `MemoryModuleTypeInit#COMPLAINT`, which stores `NPCComplaint`s
    - `NPCRenderer` now renders text above the entity regarding the complaint
    - `CNPCBrainDataSyncMessage` and `CNPCBrainDataSyncHandler` added to sync brain data to client for `NPCRenderer` to render, currently only syncs `MemoryModuleTypeInit#COMPLAINT`
        - `IWNetwork#NETWORK_VERSION` is now `"0.3.1"`, previous version was `"0.2.1"`

---
TODO: fix up the damn NPCs, they keep saying they can't access the area.