### PR TITLE
Patches related to server sync

### DIFF
--- a/src/main/java/rbasamoyai/industrialwarfare/common/blocks/NormalWorkstationBlock.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/common/blocks/NormalWorkstationBlock.java
@@ -61,7 +61,7 @@ public class NormalWorkstationBlock extends WorkstationBlock {
 	
 	@Override
 	public ActionResultType use(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockRayTraceResult hit) {
-		if (!world.isClientSide) return ActionResultType.SUCCESS;
+		if (world.isClientSide) return ActionResultType.SUCCESS;
 		if (!(player instanceof ServerPlayerEntity)) return ActionResultType.SUCCESS;
 		
 		TileEntity te = world.getBlockEntity(pos);

--- a/src/main/java/rbasamoyai/industrialwarfare/common/blocks/TaskScrollShelfBlock.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/common/blocks/TaskScrollShelfBlock.java
@@ -37,7 +37,6 @@ import net.minecraftforge.common.ToolType;
 import net.minecraftforge.fml.network.NetworkHooks;
 import rbasamoyai.industrialwarfare.IndustrialWarfare;
 import rbasamoyai.industrialwarfare.common.containers.taskscrollshelf.TaskScrollShelfContainer;
-import rbasamoyai.industrialwarfare.common.tileentities.NormalWorkstationTileEntity;
 import rbasamoyai.industrialwarfare.common.tileentities.TaskScrollShelfTileEntity;
 import rbasamoyai.industrialwarfare.utils.IWInventoryUtils;
 
@@ -133,12 +132,12 @@ public class TaskScrollShelfBlock extends Block {
 	
 	@Override
 	public ActionResultType use(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockRayTraceResult hit) {
-		if (!world.isClientSide) return ActionResultType.SUCCESS;
+		if (world.isClientSide) return ActionResultType.SUCCESS;
 		if (!(player instanceof ServerPlayerEntity)) return ActionResultType.SUCCESS;
 		
 		TileEntity te = world.getBlockEntity(pos);
 		if (te == null) return ActionResultType.FAIL;
-		if (!(te instanceof NormalWorkstationTileEntity)) return ActionResultType.FAIL;
+		if (!(te instanceof TaskScrollShelfTileEntity)) return ActionResultType.FAIL;
 		
 		IContainerProvider containerProvider = TaskScrollShelfContainer.getServerContainerProvider((TaskScrollShelfTileEntity) te, pos);
 		INamedContainerProvider namedContainerProvider = new SimpleNamedContainerProvider(containerProvider, TITLE);

--- a/src/main/java/rbasamoyai/industrialwarfare/common/capabilities/itemstacks/recipeitem/RecipeItemDataHandler.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/common/capabilities/itemstacks/recipeitem/RecipeItemDataHandler.java
@@ -8,7 +8,7 @@ import rbasamoyai.industrialwarfare.core.init.ItemInit;
 public class RecipeItemDataHandler extends QualityItemDataHandler implements IRecipeItemDataHandler {
 	
 	// Defaulting to the iron wire id to be safe
-	private ResourceLocation itemId = ItemInit.PART_IRON_WIRE.get().getRegistryName();
+	private ResourceLocation itemId = ItemInit.PART_IRON_WIRE.getId();
 
 	@Override
 	public void setItemId(Item item) {

--- a/src/main/java/rbasamoyai/industrialwarfare/common/containers/npcs/NPCContainer.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/common/containers/npcs/NPCContainer.java
@@ -212,9 +212,7 @@ public class NPCContainer extends Container {
 						brain.setMemory(MemoryModuleTypeInit.STOP_EXECUTION.get(), true);
 					});
 				} else if (slotCopy.getItem() == ItemInit.SCHEDULE.get()) {
-					this.entityOptional.ifPresent(npc -> {
-						
-					});
+					
 				}
 				
 				if (!this.moveItemStackTo(slotStack, PLAYER_INVENTORY_SLOTS_START_INDEX, NPC_EQUIPMENT_ARMOR_SLOTS_START_INDEX, true)) {

--- a/src/main/java/rbasamoyai/industrialwarfare/common/items/PartItem.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/common/items/PartItem.java
@@ -49,6 +49,26 @@ public class PartItem extends QualityItem {
 	}
 	
 	@Override
+	public CompoundNBT getShareTag(ItemStack stack) {
+		CompoundNBT tag = stack.getOrCreateTag();
+		getDataHandler(stack).ifPresent(h -> {
+			tag.put("item_cap", PartItemDataCapability.PART_ITEM_DATA_CAPABILITY.writeNBT(h, null));
+		});
+		return tag;
+	}
+	
+	@Override
+	public void readShareTag(ItemStack stack, CompoundNBT nbt) {
+		super.readShareTag(stack, nbt);
+		
+		if (nbt != null) {
+			getDataHandler(stack).ifPresent(h -> {
+				PartItemDataCapability.PART_ITEM_DATA_CAPABILITY.readNBT(h, null, nbt.getCompound("item_cap"));
+			});
+		}
+	}
+	
+	@Override
 	public void appendHoverText(ItemStack stack, World world, List<ITextComponent> tooltip, ITooltipFlag flag) {
 		super.appendHoverText(stack, world, tooltip, flag);
 		LazyOptional<IPartItemDataHandler> optional = getDataHandler(stack);
@@ -73,4 +93,9 @@ public class PartItem extends QualityItem {
 		});
 		return stack;
 	}
+	
+	public static ItemStack stackOf(Item item, float quality, int partCount, float weight) {
+		return setQualityValues(new ItemStack(item), quality, partCount, weight);
+	}
+	
 }

--- a/src/main/java/rbasamoyai/industrialwarfare/common/items/QualityItem.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/common/items/QualityItem.java
@@ -20,7 +20,7 @@ import rbasamoyai.industrialwarfare.common.capabilities.itemstacks.qualityitem.Q
 import rbasamoyai.industrialwarfare.common.capabilities.itemstacks.qualityitem.QualityItemDataProvider;
 import rbasamoyai.industrialwarfare.utils.TooltipUtils;
 
-public class QualityItem extends Item {
+public abstract class QualityItem extends Item {
 	
 	private static final IFormattableTextComponent TOOLTIP_QUALITY = new TranslationTextComponent("tooltip." + IndustrialWarfare.MOD_ID + ".quality");
 	

--- a/src/main/java/rbasamoyai/industrialwarfare/common/items/RecipeItem.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/common/items/RecipeItem.java
@@ -50,6 +50,26 @@ public class RecipeItem extends QualityItem {
 	}
 
 	@Override
+	public CompoundNBT getShareTag(ItemStack stack) {
+		CompoundNBT tag = stack.getOrCreateTag();
+		getDataHandler(stack).ifPresent(h -> {
+			tag.put("item_cap", RecipeItemDataCapability.RECIPE_ITEM_DATA_CAPABILITY.writeNBT(h, null));
+		});
+		return tag;
+	}
+	
+	@Override
+	public void readShareTag(ItemStack stack, CompoundNBT nbt) {
+		super.readShareTag(stack, nbt);
+		
+		if (nbt != null) {
+			getDataHandler(stack).ifPresent(h -> {
+				RecipeItemDataCapability.RECIPE_ITEM_DATA_CAPABILITY.readNBT(h, null, nbt.getCompound("item_cap"));
+			});
+		}
+	}
+	
+	@Override
 	public void appendHoverText(ItemStack stack, World world, List<ITextComponent> tooltip, ITooltipFlag flag) {
 		super.appendHoverText(stack, world, tooltip, flag);
 		
@@ -67,10 +87,16 @@ public class RecipeItem extends QualityItem {
 		);
 	}
 	
-	public static ItemStack getRecipeManualOf(Item recipeItem) {
-		ItemStack stack = new ItemStack(ItemInit.RECIPE_MANUAL.get());
-		getDataHandler(stack).ifPresent(h -> h.setItemId(recipeItem));
+	public static ItemStack setQualityValues(ItemStack stack, Item recipeItem, float quality) {
+		getDataHandler(stack).ifPresent(h -> {
+			QualityItem.setQualityValues(stack, quality);
+			h.setItemId(recipeItem);
+		});
 		return stack;
+	}
+	
+	public static ItemStack stackOf(Item recipeItem, float quality) {
+		return setQualityValues(new ItemStack(ItemInit.RECIPE_MANUAL.get()), recipeItem, quality);
 	}
 	
 }

--- a/src/main/java/rbasamoyai/industrialwarfare/core/itemgroup/IWItemGroups.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/core/itemgroup/IWItemGroups.java
@@ -7,8 +7,8 @@ import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.util.NonNullList;
+import net.minecraftforge.fml.RegistryObject;
 import rbasamoyai.industrialwarfare.common.items.PartItem;
-import rbasamoyai.industrialwarfare.common.items.QualityItem;
 import rbasamoyai.industrialwarfare.common.items.RecipeItem;
 import rbasamoyai.industrialwarfare.core.init.ItemInit;
 
@@ -62,15 +62,15 @@ public class IWItemGroups {
 		@Override
 		public void fillItemList(NonNullList<ItemStack> items) {
 			items.addAll(Arrays.asList(
-					getItemStack(ItemInit.HAMMER.get()),
-					getItemStack(ItemInit.WAND.get()),
-					getItemStack(ItemInit.CURED_FLESH.get()),
-					getItemStack(ItemInit.BODY_PART.get()),
-					getItemStack(ItemInit.MAKESHIFT_BRAIN.get()),
-					getItemStack(ItemInit.MAKESHIFT_HEAD.get()),
-					getItemStack(ItemInit.TASK_SCROLL.get()),
-					getItemStack(ItemInit.LABEL.get()),
-					getItemStack(ItemInit.SCHEDULE.get())
+					getItemStack(ItemInit.HAMMER),
+					getItemStack(ItemInit.WAND),
+					getItemStack(ItemInit.CURED_FLESH),
+					getItemStack(ItemInit.BODY_PART),
+					getItemStack(ItemInit.MAKESHIFT_BRAIN),
+					getItemStack(ItemInit.MAKESHIFT_HEAD),
+					getItemStack(ItemInit.TASK_SCROLL),
+					getItemStack(ItemInit.LABEL),
+					getItemStack(ItemInit.SCHEDULE)
 					));
 		}
 		
@@ -100,8 +100,8 @@ public class IWItemGroups {
 		@Override
 		public void fillItemList(NonNullList<ItemStack> items) {
 			items.addAll(Arrays.asList(
-					getItemStack(ItemInit.ASSEMBLER_WORKSTATION.get()),
-					getItemStack(ItemInit.TASK_SCROLL_SHELF.get())
+					getItemStack(ItemInit.ASSEMBLER_WORKSTATION),
+					getItemStack(ItemInit.TASK_SCROLL_SHELF)
 					));
 		}
 		
@@ -115,8 +115,8 @@ public class IWItemGroups {
 		@Override
 		public void fillItemList(NonNullList<ItemStack> items) {
 			items.addAll(Arrays.asList(
-					PartItem.setQualityValues(getItemStack(ItemInit.PART_IRON_WIRE.get()), 1.0f, 1, 1.0f),
-					PartItem.setQualityValues(getItemStack(ItemInit.PART_SCREW.get()), 1.0f, 1, 1.0f)
+					PartItem.stackOf(ItemInit.PART_IRON_WIRE.get(), 1.0f, 1, 1.0f),
+					PartItem.stackOf(ItemInit.PART_SCREW.get(), 1.0f, 1, 1.0f)
 					));
 		}
 			
@@ -130,8 +130,8 @@ public class IWItemGroups {
 		@Override
 		public void fillItemList(NonNullList<ItemStack> items) {
 			items.addAll(Arrays.asList(
-					QualityItem.setQualityValues(RecipeItem.getRecipeManualOf(ItemInit.PART_IRON_WIRE.get()), 1.0f),
-					QualityItem.setQualityValues(RecipeItem.getRecipeManualOf(ItemInit.PART_SCREW.get()), 1.0f)
+					RecipeItem.stackOf(ItemInit.PART_IRON_WIRE.get(), 1.0f),
+					RecipeItem.stackOf(ItemInit.PART_SCREW.get(), 1.0f)
 					));
 		}
 		
@@ -157,6 +157,10 @@ public class IWItemGroups {
 	
 	private static ItemStack getItemStack(Item item) {
 		return new ItemStack(item);
+	}
+	
+	private static ItemStack getItemStack(RegistryObject<Item> item) {
+		return getItemStack(item.get());
 	}
 	
 }

--- a/src/main/java/rbasamoyai/industrialwarfare/utils/TooltipUtils.java
+++ b/src/main/java/rbasamoyai/industrialwarfare/utils/TooltipUtils.java
@@ -13,7 +13,6 @@ import net.minecraft.util.text.LanguageMap;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraft.util.text.TextProcessing;
 import net.minecraft.util.text.TranslationTextComponent;
 import rbasamoyai.industrialwarfare.IndustrialWarfare;
 
@@ -56,12 +55,11 @@ public class TooltipUtils {
 	}
 	
 	public static int charLength(ITextComponent tc) {
-		MutableInt length = new MutableInt(0);
-		TextProcessing.iterateFormatted(tc, Style.EMPTY, (index, style, codepoint) -> {
-			length.increment();
-			return true;
-		});
-		return length.intValue();
+		int len = tc.getContents().length();
+		for (ITextComponent sibling : tc.getSiblings()) {
+			len += charLength(sibling);
+		}
+		return len;
 	}
 	
 	public static String formatFloat(float f) {


### PR DESCRIPTION
- Fixed issue where tile entity blocks would not open for interfacing when right clicked
- Fixed issue where `TaskScrollShelfContainer` wouldn't update the TE
    - `TaskScrollShelfContainer` now also has a parameter for `Optional<TaskScrollShelfTileEntity>` to make the above possible
- Fixed issue where `QualityItem`-derived items would lose data when taken from creative inventory
    - `QualityItem` is now abstract, must now implement `Item#getShareTag` and `Item#readShareTag`
- Some code shortenings